### PR TITLE
Vscode lsp

### DIFF
--- a/src/igpop/core.clj
+++ b/src/igpop/core.clj
@@ -2,7 +2,8 @@
   (:require [clj-yaml.core :as yaml]
             [clojure.java.io :as io]
             [igpop.site.core :as site]
-            [clojure.set])
+            [clojure.set]
+            [igpop.lsp.core :as lsp])
   (:gen-class))
 
 (defmulti run (fn [nm & args] (keyword nm)))
@@ -15,7 +16,9 @@
    "build"    {:fn :build
                :desc "USAGE: igpop build {your_baseurl} EXAMPLE: igpop build /igpop"}
    "dev"      {:fn :dev
-               :desc "-p to setup a port (default is 8899)"}})
+               :desc "-p to setup a port (default is 8899)"}
+   "lsp"      {:fn :lsp
+               :desc "-p to setup a port (default is 7345)"}})
 
 (defmethod run
   :help
@@ -46,6 +49,18 @@
       (site/start (System/getProperty "user.dir") (Integer. port))
       (and (< i 0) (= "dev" port))
       (site/start (System/getProperty "user.dir") 8899)
+      :else
+      (run :help))))
+
+(defmethod run
+  :lsp
+  [& args]
+  (println "LSP..." args)
+  (let [i (.indexOf args "-p")
+        port (last args)]
+    (cond
+      (and (> i 0) (not (= "-p" port))) (lsp/start (System/getProperty "user.dir") (Integer. port))
+      (and (< i 0) (= "lsp" port)) (lsp/start (System/getProperty "user.dir") 7345)
       :else
       (run :help))))
 

--- a/src/igpop/lsp/core.clj
+++ b/src/igpop/lsp/core.clj
@@ -199,6 +199,26 @@
 ;;   [ctx msg]
 ;;   {:result {}})
 
+(defn start [^String home ^Integer port]
+  (let [log-file "/tmp/igpop-lsp.log"
+        xlog (fn  [msg]
+               (with-open [w (io/writer log-file :append true)]
+                 (.write w msg)
+                 (.write w "\n")))]
+
+    (json-rpc.core/start (atom {:type :tcp
+                                :block? true
+                                :port port
+                                :json-rpc {:request (fn [_ msg]
+                                                      (xlog (str "-> " (:method msg) " " (:id msg)))
+                                                      (xlog (zp/zprint-str msg)))
+                                           :response (fn [_ resp]
+                                                       (xlog (str "<- " (:id resp)))
+                                                       (xlog (zp/zprint-str resp)))
+                                           :notify (fn [_ note]
+                                                     (xlog (str "<! " (:method note)))
+                                                     (xlog (zp/zprint-str note)))}
+                                :manifest (igpop.loader/load-project home)}))))
 
 
 

--- a/src/igpop/lsp/core.clj
+++ b/src/igpop/lsp/core.clj
@@ -199,24 +199,10 @@
 ;;   {:result {}})
 
 (defn start [^String home ^Integer port]
-  (let [log-file "/tmp/igpop-lsp.log"
-        xlog (fn  [msg]
-               (with-open [w (io/writer log-file :append true)]
-                 (.write w msg)
-                 (.write w "\n")))
-        group (AsynchronousChannelGroup/withThreadPool (Executors/newSingleThreadExecutor))]
+  (let [group (AsynchronousChannelGroup/withThreadPool (Executors/newSingleThreadExecutor))]
 
     (json-rpc.core/start (atom {:type :tcp
                                 :port port
-                                :json-rpc {:request (fn [_ msg]
-                                                      (xlog (str "-> " (:method msg) " " (:id msg)))
-                                                      (xlog (zp/zprint-str msg)))
-                                           :response (fn [_ resp]
-                                                       (xlog (str "<- " (:id resp)))
-                                                       (xlog (zp/zprint-str resp)))
-                                           :notify (fn [_ note]
-                                                     (xlog (str "<! " (:method note)))
-                                                     (xlog (zp/zprint-str note)))}
                                 :manifest (igpop.loader/load-project home)})
                          group)
     (.awaitTermination group (Long/MAX_VALUE) (TimeUnit/SECONDS))))

--- a/src/igpop/lsp/core.clj
+++ b/src/igpop/lsp/core.clj
@@ -19,8 +19,8 @@
                                       ;; and TextDocumentSyncKind.Incremental. If omitted it defaults to TextDocumentSyncKind.None.
                                       ;; number;
                                       ;; None = 0;
-                                        ;; Full = 1;
-                                        ;; Incremental = 2;
+	                                    ;; Full = 1;
+	                                    ;; Incremental = 2;
                                       :change 1
                                       ;; If present will save notifications are sent to the server. If omitted the notification should not be
                                       ;; sent.
@@ -58,25 +58,25 @@
                    ;; :foldingRangeProvider true ;;| FoldingRangeProviderOptions | (FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions);
                    ;; The server provides go to declaration support.
                    ;; :declarationProvider true ;; | (TextDocumentRegistrationOptions & StaticRegistrationOptions);
-                     ;; The server provides execute command support.
-                     ;; :executeCommandProvider ExecuteCommandOptions;
-                     ;; Workspace specific server capabilities
+	                 ;; The server provides execute command support.
+	                 ;; :executeCommandProvider ExecuteCommandOptions;
+	                 ;; Workspace specific server capabilities
 
                    :workspace {
-                                   ;;The server supports workspace folder.
-                                   :workspaceFolders {
-                                                        ;;* The server has support for workspace folders
-                                                        :supported true
-                                                        ;; Whether the server wants to receive workspace folder
-                                                        ;; change notifications.
+		                           ;;The server supports workspace folder.
+		                           :workspaceFolders {
+			                                            ;;* The server has support for workspace folders
+			                                            :supported true
+			                                            ;; Whether the server wants to receive workspace folder
+			                                            ;; change notifications.
                                         ;
-                                                        ;; If a strings is provided the string is treated as a ID
-                                                        ;; under which the notification is registered on the client
-                                                        ;; side. The ID can be used to unregister for these events
-                                                        ;; using the `client/unregisterCapability` request.
-                                                        :changeNotifications true ;;: string | boolean;
-                                                      }
-                                 }
+			                                            ;; If a strings is provided the string is treated as a ID
+			                                            ;; under which the notification is registered on the client
+			                                            ;; side. The ID can be used to unregister for these events
+			                                            ;; using the `client/unregisterCapability` request.
+			                                            :changeNotifications true ;;: string | boolean;
+		                                              }
+	                             }
                    }
 
     }})

--- a/src/igpop/lsp/core.clj
+++ b/src/igpop/lsp/core.clj
@@ -19,8 +19,8 @@
                                       ;; and TextDocumentSyncKind.Incremental. If omitted it defaults to TextDocumentSyncKind.None.
                                       ;; number;
                                       ;; None = 0;
-                                      ;; Full = 1;
-                                      ;; Incremental = 2;
+                                        ;; Full = 1;
+                                        ;; Incremental = 2;
                                       :change 1
                                       ;; If present will save notifications are sent to the server. If omitted the notification should not be
                                       ;; sent.
@@ -63,20 +63,20 @@
                      ;; Workspace specific server capabilities
 
                    :workspace {
-                               ;;The server supports workspace folder.
-                               :workspaceFolders {
-                                                  ;;* The server has support for workspace folders
-                                                  :supported true
-                                                  ;; Whether the server wants to receive workspace folder
-                                                  ;; change notifications.
+                                   ;;The server supports workspace folder.
+                                   :workspaceFolders {
+                                                        ;;* The server has support for workspace folders
+                                                        :supported true
+                                                        ;; Whether the server wants to receive workspace folder
+                                                        ;; change notifications.
                                         ;
-                                                  ;; If a strings is provided the string is treated as a ID
-                                                  ;; under which the notification is registered on the client
-                                                  ;; side. The ID can be used to unregister for these events
-                                                  ;; using the `client/unregisterCapability` request.
-                                                  :changeNotifications true ;;: string | boolean;
-                                                  }
-                               }
+                                                        ;; If a strings is provided the string is treated as a ID
+                                                        ;; under which the notification is registered on the client
+                                                        ;; side. The ID can be used to unregister for these events
+                                                        ;; using the `client/unregisterCapability` request.
+                                                        :changeNotifications true ;;: string | boolean;
+                                                      }
+                                 }
                    }
 
     }})

--- a/src/igpop/lsp/core.clj
+++ b/src/igpop/lsp/core.clj
@@ -19,8 +19,8 @@
                                       ;; and TextDocumentSyncKind.Incremental. If omitted it defaults to TextDocumentSyncKind.None.
                                       ;; number;
                                       ;; None = 0;
-                                        ;; Full = 1;
-                                        ;; Incremental = 2;
+                                      ;; Full = 1;
+                                      ;; Incremental = 2;
                                       :change 1
                                       ;; If present will save notifications are sent to the server. If omitted the notification should not be
                                       ;; sent.
@@ -63,20 +63,20 @@
                      ;; Workspace specific server capabilities
 
                    :workspace {
-                                   ;;The server supports workspace folder.
-                                   :workspaceFolders {
-                                                        ;;* The server has support for workspace folders
-                                                        :supported true
-                                                        ;; Whether the server wants to receive workspace folder
-                                                        ;; change notifications.
+                               ;;The server supports workspace folder.
+                               :workspaceFolders {
+                                                  ;;* The server has support for workspace folders
+                                                  :supported true
+                                                  ;; Whether the server wants to receive workspace folder
+                                                  ;; change notifications.
                                         ;
-                                                        ;; If a strings is provided the string is treated as a ID
-                                                        ;; under which the notification is registered on the client
-                                                        ;; side. The ID can be used to unregister for these events
-                                                        ;; using the `client/unregisterCapability` request.
-                                                        :changeNotifications true ;;: string | boolean;
-                                                      }
-                                 }
+                                                  ;; If a strings is provided the string is treated as a ID
+                                                  ;; under which the notification is registered on the client
+                                                  ;; side. The ID can be used to unregister for these events
+                                                  ;; using the `client/unregisterCapability` request.
+                                                  :changeNotifications true ;;: string | boolean;
+                                                  }
+                               }
                    }
 
     }})

--- a/src/json_rpc/core.clj
+++ b/src/json_rpc/core.clj
@@ -25,18 +25,19 @@
       (http/send! chann (cheshire.core/generate-string msg))
       (json-rpc.tcp/send-message chann msg))))
 
-(defn start [ctx]
-  (let [tp (:type @ctx)
-        {on-req :request on-resp :response} (:json-rpc @ctx)
-        handler (fn [conn msg]
-                  (when on-req (on-req @ctx msg))
-                  (let [resp (proc (assoc @ctx :channel conn) msg)]
-                    (when on-resp (on-resp @ctx resp))
-                    resp))]
-    (swap! ctx assoc :handler handler)
-    (if (= tp :tcp)
-      (json-rpc.tcp/start ctx)
-      (assert false "Not. impl"))))
+(defn start
+  ([ctx] (start ctx nil))
+  ([ctx group] (let [tp (:type @ctx)
+            {on-req :request on-resp :response} (:json-rpc @ctx)
+            handler (fn [conn msg]
+                      (when on-req (on-req @ctx msg))
+                      (let [resp (proc (assoc @ctx :channel conn) msg)]
+                        (when on-resp (on-resp @ctx resp))
+                        resp))]
+        (swap! ctx assoc :handler handler)
+        (if (= tp :tcp)
+          (json-rpc.tcp/start ctx group)
+          (assert false "Not. impl")))))
 
 
 (defn stop [ctx]
@@ -44,5 +45,3 @@
     (if (= tp :tcp)
       (json-rpc.tcp/stop ctx)
       (assert false "Not. impl"))))
-
-

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*\.vsix

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -7,7 +7,7 @@
 - Go to Extensions view though Views menu
 - Press three points sign on top of view then chose Install from VSIX, select downloaded file
 - Wait for installation process complete
-- [Optional] If you have igpop executable, you may specify path to it from extension config
+- [Optional] If you have igpop executable, you may specify path to it from extension config, else executable will be downloaded automaticlly
 
 ## Usage
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -7,7 +7,7 @@
 - Go to Extensions view though Views menu
 - Press three points sign on top of view then chose Install from VSIX, select downloaded file
 - Wait for installation process complete
-- Specify path to igpop executable in extension config. To open config press gear sign on extansion pane.
+- Specify path to igpop executable in extension config `igpoplsp.path` parameter in `settings.json` file. To open config press gear sign on extansion pane.
 
 ## Usage
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,38 +1,18 @@
-# LSP Example
+# Igpop LSP extension for VSCode
 
-Heavily documented sample code for https://code.visualstudio.com/api/language-extensions/language-server-extension-guide
+## Installing
 
-## Functionality
+- Download extension file igpop-lsp-x.y.z.vsix
+- Run VSCode
+- Go to Extensions view though Views menu
+- Press three points sign on top of view then chose Install from VSIX, select downloaded file
+- Wait for installation process complete
+- [Optional] If you have igpop executable, you may specify path to it from extension config
 
-This Language Server works for plain text file. It has the following language features:
-- Completions
-- Diagnostics regenerated on each file change or configuration change
+## Usage
 
-It also includes an End-to-End test.
+Extention will automaticlly run when igpop project will be opened.
 
-## Structure
+## Notes
 
-```
-.
-├── client // Language Client
-│   ├── src
-│   │   ├── test // End to End tests for Language Client / Server
-│   │   └── extension.ts // Language Client entry point
-├── package.json // The extension manifest.
-└── server // Language Server
-    └── src
-        └── server.ts // Language Server entry point
-```
-
-## Running the Sample
-
-- Run `npm install` in this folder. This installs all necessary npm modules in both the client and server folder
-- Open VS Code on this folder.
-- Press Ctrl+Shift+B to compile the client and server.
-- Switch to the Debug viewlet.
-- Select `Launch Client` from the drop down.
-- Run the launch config.
-- If you want to debug the server as well use the launch configuration `Attach to Server`
-- In the [Extension Development Host] instance of VSCode, open a document in 'plain text' language mode.
-  - Type `j` or `t` to see `Javascript` and `TypeScript` completion.
-  - Enter text content such as `AAA aaa BBB`. The extension will emit diagnostics for all words in all-uppercase.
+Support for auto restart server not implemented yet. If you encountered error, you'll need to manual reopen project

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -2,12 +2,12 @@
 
 ## Installing
 
-- Download extension file igpop-lsp-x.y.z.vsix
+- Download extension file igpop-lsp-x.y.z.vsix and igpop executable
 - Run VSCode
 - Go to Extensions view though Views menu
 - Press three points sign on top of view then chose Install from VSIX, select downloaded file
 - Wait for installation process complete
-- [Optional] If you have igpop executable, you may specify path to it from extension config, else executable will be downloaded automaticlly
+- Specify path to igpop executable in extension config. To open config press gear sign on extansion pane.
 
 ## Usage
 

--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -1,4 +1,3 @@
-const path = require("path");
 const vscode = require('vscode');
 const lsp = require('vscode-languageclient');
 const net = require('net');
@@ -23,19 +22,24 @@ function activate(context) {
     return new Promise((resolve, reject) => {
       let port;
       server.listen(0, '127.0.0.1', () => {
-        console.log('Starting server')
+        console.log('Spawning igpop Language Server...')
         const port = server.address().port;
         var path = getPath();
         var args = ["lsp", "-p", port];
         server.close(() => {
             client.serverProcess = spawn(path, args, {cwd: vscode.workspace.rootPath} );
           resolve(port);
+          client.serverProcess.stderr.on('data', chunk => {
+            const str = chunk.toString();
+            console.log('igpop Language Server:', str);
+            client.outputChannel.appendLine(str);
+          });
           client.serverProcess.on('exit', (code, signal) => {
             if (code !== 0) {
-              console.log(`Language server exited ` + (signal ? `from signal ${signal}` : `with exit code ${code}`));
+              console.log(`igpop Language Server exited ` + (signal ? `from signal ${signal}` : `with exit code ${code}`));
             }
           });
-          console.log(`Server spawned on port ${port}`)
+          console.log(`igpop Language Server process spawned on port ${port}`)
         });
       });
     });
@@ -84,10 +88,8 @@ function activate(context) {
   client.start();
   context.subscriptions.push(client);
 
-  console.log('Congratulations, your extension "hello" is now active!');
-
-  let disposable = vscode.commands.registerCommand('extension.helloWorld', function () {
-    vscode.window.showInformationMessage('Hello World!');
+  let disposable = vscode.commands.registerCommand('extension.igpop-lsp', function () {
+    vscode.window.showInformationMessage('Enable igpop LSP extension');
   });
 
   context.subscriptions.push(disposable);

--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -2,14 +2,48 @@ const path = require("path");
 const vscode = require('vscode');
 const lsp = require('vscode-languageclient');
 const net = require('net');
+const { spawn } = require('child_process');
 
 function activate(context) {
+  let client;
+  let tcpServerOptions = () => new Promise((resolve, reject) => {
+    const server = net.createServer(socket => {
+      console.log('Process connected');
+      socket.on('end', () => {
+        console.log('Process disconnected');
+      });
+      server.close();
+      resolve({ reader: socket, writer: socket });
+    });
+    // Listen on random port
+    server.listen(0, '127.0.0.1', () => {
+      console.log('Starting server')
+      const port = (server.address()).port;
+      var path = "/usr/bin/java"
+      var args = ["-jar", "/home/flawless/projects/igpop/target/igpop.jar",
+                  "lsp", "-p", port];
+      const childProcess = spawn(path, args, {cwd: '/home/flawless/projects/igpop/example'} );
+      console.log('Server spawned')
+      childProcess.stderr.on('data', chunk => {
+        const str = chunk.toString();
+        console.log('Igpop Language Server:', str);
+        client.outputChannel.appendLine(str);
+      });
+      childProcess.on('exit', (code, signal) => {
+        client.outputChannel.appendLine(`Language server exited ` + (signal ? `from signal ${signal}` : `with exit code ${code}`));
+        if (code !== 0) {
+          client.outputChannel.show();
+        }
+      });
+      return childProcess;
+    });
+  });
     // let serverOptions = {
     //     run: {
-    //         port: 7345,
-    //         transport: lsp.TransportKind.socket,
-    //         command: "bash",
-    //         args: ["-c", "sleep 10000"]
+    //       port: 7345,
+    //       transport: lsp.TransportKind.socket,
+    //       command: "java",
+    //       args: ["--jar", "/home/flawless/projects/igpop/target/igpop.jar", "lsp"]
     //     },
     //     debug: {
     //         port: 7345,
@@ -20,68 +54,67 @@ function activate(context) {
     //     }
     // };
 
-        server = context.asAbsolutePath(path.join('server.js'));
 
-        let serverOptions = function(args){
-            return new Promise(function(resolve, reject){
-                var client = new net.Socket();
-                var result = {}
-                client.connect(7345, "127.0.0.1", function() {
-                   console.log('connected');
-                   result.reader = client;
-                   result.reader = client;
-                   resolve({
-                        reader: client,
-                        writer: client
-                    });
-                });
-                client.on('closed', () => {
-                   console.log('socket closed, try reconnect');
-                   setTimeout(()=>{
-                      try { 
-                          client.end();
-                      } finally {}
-                      client = new net.Socket();
-                      client.connect(7345, "127.0.0.1", function() {
-                        console.log('Re-connected');
-                        result.reader = client;
-                        result.reader = client;
-                      });
+        // let serverOptions = function(args){
+        //     return new Promise(function(resolve, reject){
+        //         var client = new net.Socket();
+        //         var result = {}
+        //         client.connect(7345, "127.0.0.1", function() {
+        //            console.log('connected');
+        //            result.reader = client;
+        //            result.reader = client;
+        //            resolve({
+        //                 reader: client,
+        //                 writer: client
+        //             });
+        //         });
+        //         client.on('closed', () => {
+        //            console.log('socket closed, try reconnect');
+        //            setTimeout(()=>{
+        //               try {
+        //                   client.end();
+        //               } finally {}
+        //               client = new net.Socket();
+        //               client.connect(7345, "127.0.0.1", function() {
+        //                 console.log('Re-connected');
+        //                 result.reader = client;
+        //                 result.reader = client;
+        //               });
 
-                   }, 2000);
-                   
-                });
-            });
-			
-        };
+        //            }, 2000);
 
-        let clientOptions = {
-            documentSelector: [{ scheme: 'file', language: 'igpop' }],
-            synchronize: {
-                // Notify the server about file changes to '.clientrc files contained in the workspace
-                configurationSection: 'igpop-lsp',
-                fileEvents: [
-                    vscode.workspace.createFileSystemWatcher('**/*.igpop')
-                ]
-            }
-        };
-    client = new lsp.LanguageClient('igpop', 'Language Server Igpop', serverOptions, clientOptions);
-    client.start();
-    context.subscriptions.push(client);
+        //         });
+        //     });
 
-	  console.log('Congratulations, your extension "hello" is now active!');
+        // };
 
-	  let disposable = vscode.commands.registerCommand('extension.helloWorld', function () {
-		    vscode.window.showInformationMessage('Hello World!');
-	  });
+  let clientOptions = {
+    documentSelector: [{ scheme: 'file', language: 'igpop' }],
+    synchronize: {
+      // Notify the server about file changes to '.clientrc files contained in the workspace
+      configurationSection: 'igpop-lsp',
+      fileEvents: [
+        vscode.workspace.createFileSystemWatcher('**/*.igpop')
+      ]
+    }
+  };
+  client = new lsp.LanguageClient('igpop', 'Language Server Igpop', tcpServerOptions, clientOptions);
+  client.start();
+  context.subscriptions.push(client);
 
-	  context.subscriptions.push(disposable);
+  console.log('Congratulations, your extension "hello" is now active!');
+
+  let disposable = vscode.commands.registerCommand('extension.helloWorld', function () {
+    vscode.window.showInformationMessage('Hello World!');
+  });
+
+  context.subscriptions.push(disposable);
 }
 exports.activate = activate;
 function deactivate() {
-    if (!client) {
-        return undefined;
-    }
-    return client.stop();
+  if (!client) {
+    return undefined;
+  }
+  return client.stop();
 }
 exports.deactivate = deactivate;

--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -4,6 +4,10 @@ const lsp = require('vscode-languageclient');
 const net = require('net');
 const { spawn } = require('child_process');
 
+function getPath() {
+    return vscode.workspace.getConfiguration('igpoplsp').get('path');
+}
+
 function activate(context) {
   let client;
   const server = net.createServer(socket => {
@@ -21,11 +25,10 @@ function activate(context) {
       server.listen(0, '127.0.0.1', () => {
         console.log('Starting server')
         const port = server.address().port;
-        var path = "/usr/bin/java"
-        var args = ["-jar", "/home/flawless/projects/igpop/target/igpop.jar",
-                    "lsp", "-p", port];
+        var path = getPath();
+        var args = ["lsp", "-p", port];
         server.close(() => {
-          client.serverProcess = spawn(path, args, {cwd: '/home/flawless/projects/igpop/example'} );
+            client.serverProcess = spawn(path, args, {cwd: vscode.workspace.rootPath} );
           resolve(port);
           client.serverProcess.on('exit', (code, signal) => {
             if (code !== 0) {

--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -65,6 +65,12 @@ function activate(context) {
             connect(client, port)
           }, 1000);
         });
+        client.on('connect', () => {
+          console.log('client connected');
+          client.on('error', () => {
+            console.log('disconnected')
+          });
+        });
       });
     });
   });

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -4,10 +4,471 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/node": {
+			"version": "14.0.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.6.tgz",
+			"integrity": "sha512-FbNmu4F67d3oZMWBV6Y4MaPER+0EpE9eIYf2yaHhCWovc1dlXCZkqGX4NLHfVVr6umt20TNBdRzrNJIzIKfdbw=="
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"azure-devops-node-api": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+			"integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+			"requires": {
+				"os": "0.1.1",
+				"tunnel": "0.0.4",
+				"typed-rest-client": "1.2.0",
+				"underscore": "1.8.3"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"cheerio": {
+			"version": "1.0.0-rc.3",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+			"requires": {
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.1",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash": "^4.15.0",
+				"parse5": "^3.0.1"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"css-select": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"requires": {
+				"boolbase": "~1.0.0",
+				"css-what": "2.1",
+				"domutils": "1.5.1",
+				"nth-check": "~1.0.1"
+			}
+		},
+		"css-what": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+		},
+		"denodeify": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+			"integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE="
+		},
+		"dom-serializer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+			"requires": {
+				"domelementtype": "^1.3.0",
+				"entities": "^1.1.1"
+			}
+		},
+		"domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+		},
+		"domhandler": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"requires": {
+				"domelementtype": "1"
+			}
+		},
+		"domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"requires": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
+		"entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+			"requires": {
+				"pend": "~1.2.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"htmlparser2": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"requires": {
+				"domelementtype": "^1.3.1",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.1.1"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+		},
+		"linkify-it": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+			"requires": {
+				"uc.micro": "^1.0.1"
+			}
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
+		"markdown-it": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+			"integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"entities": "~2.0.0",
+				"linkify-it": "^2.0.0",
+				"mdurl": "^1.0.1",
+				"uc.micro": "^1.0.5"
+			},
+			"dependencies": {
+				"entities": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+					"integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+				}
+			}
+		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+		},
+		"mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+		},
+		"nth-check": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"requires": {
+				"boolbase": "~1.0.0"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"os": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+			"integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"osenv": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
+			}
+		},
+		"parse-semver": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+			"integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
+			"requires": {
+				"semver": "^5.1.0"
+			}
+		},
+		"parse5": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+		},
+		"read": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"requires": {
+				"mute-stream": "~0.0.4"
+			}
+		},
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"tmp": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+			"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+			"requires": {
+				"os-tmpdir": "~1.0.1"
+			}
+		},
+		"tunnel": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+			"integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+		},
+		"typed-rest-client": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+			"integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+			"requires": {
+				"tunnel": "0.0.4",
+				"underscore": "1.8.3"
+			}
+		},
+		"uc.micro": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+		},
+		"underscore": {
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+		},
+		"url-join": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+			"integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"vsce": {
+			"version": "1.75.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.75.0.tgz",
+			"integrity": "sha512-qyAQTmolxKWc9bV1z0yBTSH4WEIWhDueBJMKB0GUFD6lM4MiaU1zJ9BtzekUORZu094YeNSKz0RmVVuxfqPq0g==",
+			"requires": {
+				"azure-devops-node-api": "^7.2.0",
+				"chalk": "^2.4.2",
+				"cheerio": "^1.0.0-rc.1",
+				"commander": "^2.8.1",
+				"denodeify": "^1.2.1",
+				"glob": "^7.0.6",
+				"leven": "^3.1.0",
+				"lodash": "^4.17.15",
+				"markdown-it": "^10.0.0",
+				"mime": "^1.3.4",
+				"minimatch": "^3.0.3",
+				"osenv": "^0.1.3",
+				"parse-semver": "^1.1.1",
+				"read": "^1.0.7",
+				"semver": "^5.1.0",
+				"tmp": "0.0.29",
+				"typed-rest-client": "1.2.0",
+				"url-join": "^1.1.0",
+				"yauzl": "^2.3.1",
+				"yazl": "^2.2.2"
+			}
 		},
 		"vscode-jsonrpc": {
 			"version": "4.0.0",
@@ -36,6 +497,28 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
 			"integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+			"requires": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
+		"yazl": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+			"requires": {
+				"buffer-crc32": "~0.2.3"
+			}
 		}
 	}
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,32 +1,44 @@
 {
-    "name": "lsp-sample",
-    "description": "A language server example",
-    "author": "Microsoft Corporation",
+    "name": "igpop-lsp",
+    "description": "A igpop Language Server",
+    "author": "nobody",
     "license": "MIT",
     "version": "1.0.0",
     "repository": {
         "type": "git",
         "url": ""
     },
-    "publisher": "vscode-samples",
+    "publisher": "flawless",
     "categories": [],
     "engines": {
         "vscode": "^1.33.0"
     },
     "activationEvents": [
-        "*"
+        "onCommand:extension.sayLSP",
+        "workspaceContains:ig.yaml"
     ],
     "main": "./extension.js",
     "dependencies": {
+        "vsce": "^1.75.0",
         "vscode-languageclient": "^5.2.1"
     },
     "contributes": {
         "commands": [
             {
-                "command": "extension.helloWorld",
-                "title": "Hello World"
+                "command": "extension.igpop-lsp",
+                "title": "igpop Language Server"
             }
         ],
+        "configuration": {
+            "title": "igpop LSP",
+            "properties": {
+                "igpoplsp.path": {
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "Path to igpop executable. Default null"
+                }
+            }
+        },
         "languages": [
             {
                 "id": "igpop",
@@ -34,10 +46,10 @@
                     "igpop"
                 ],
                 "extensions": [
-                  ".igpop",
-                  ".igp",
-                  ".yaml",
-                  ".yml"
+                    ".igpop",
+                    ".igp",
+                    ".yaml",
+                    ".yml"
                 ],
                 "configuration": "./language-configuration.json"
             }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,50 +1,53 @@
 {
-	"name": "lsp-sample",
-	"description": "A language server example",
-	"author": "Microsoft Corporation",
-	"license": "MIT",
-	"version": "1.0.0",
-	"repository": {
-		"type": "git",
-		"url": ""
-	},
-	"publisher": "vscode-samples",
-	"categories": [],
-	"engines": {
-		"vscode": "^1.33.0"
-	},
-	"activationEvents": [
-		"*"
-	],
-	"main": "./extension.js",
-	"dependencies": {
-		"vscode-languageclient": "^5.2.1"
-	},
-	"contributes": {
-		"commands": [
-			{
-				"command": "extension.helloWorld",
-				"title": "Hello World"
-			}
-		],
-		"languages": [
-			{
-				"id": "igpop",
-				"aliases": [
-					"igpop"
-				],
-				"extensions": [
-					".igpop"
-				],
-				"configuration": "./language-configuration.json"
-			}
-		],
-		"grammars": [
-			{
-				"language": "igpop",
-				"scopeName": "source.igpop",
-				"path": "./syntaxes/igpop.tmLanguage.json"
-			}
-		]
-	}
+    "name": "lsp-sample",
+    "description": "A language server example",
+    "author": "Microsoft Corporation",
+    "license": "MIT",
+    "version": "1.0.0",
+    "repository": {
+        "type": "git",
+        "url": ""
+    },
+    "publisher": "vscode-samples",
+    "categories": [],
+    "engines": {
+        "vscode": "^1.33.0"
+    },
+    "activationEvents": [
+        "*"
+    ],
+    "main": "./extension.js",
+    "dependencies": {
+        "vscode-languageclient": "^5.2.1"
+    },
+    "contributes": {
+        "commands": [
+            {
+                "command": "extension.helloWorld",
+                "title": "Hello World"
+            }
+        ],
+        "languages": [
+            {
+                "id": "igpop",
+                "aliases": [
+                    "igpop"
+                ],
+                "extensions": [
+                  ".igpop",
+                  ".igp",
+                  ".yaml",
+                  ".yml"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "igpop",
+                "scopeName": "source.igpop",
+                "path": "./syntaxes/igpop.tmLanguage.json"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
Added ability to launch standalone LSP server via, and VScode extension to work with Igpop files.

Extension automatically handles `.yml`, `.yaml`, `.igp` and `.igpop` files, launch and maintain LSP server and provide LSP features when editing this files. Igpop executable must be installed in system and path to this executable must be defined in extension config as `igpoplsp.path` parameter in extensions settings.json file, config and installation process of extension also described in extension readme.

As future features there may be automatic Igpop installation while extension loading.