### PR TITLE
Add support :publisher and :date props for ig.yml. bump npm version 0.5.0 -> 0.5.1

### DIFF
--- a/npm/igpop/package.json
+++ b/npm/igpop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "igpop-cli",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Sugar FHIR profiling for programming beings",
     "author": "niquola",
     "license": "MIT",


### PR DESCRIPTION
Now we can add `publisher`, `date` properties to `ig.yaml` file. 
They will spread across whole generated structure-definitions.
Also there are possibility to override these properties directly in profiles