### PR TITLE
Rename FHIR package. Add sd files without .json extension to quickly fix 404

### DIFF
--- a/npm/igpop/package.json
+++ b/npm/igpop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "igpop-cli",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "description": "Sugar FHIR profiling for programming beings",
     "author": "niquola",
     "license": "MIT",

--- a/src/igpop/fhir_package.clj
+++ b/src/igpop/fhir_package.clj
@@ -96,11 +96,12 @@
 
 (defn generate-fhir-package!
   "Create FHIR Package file and returns it.
-  Creates tgz file in `/[project-home]/build/[project-id].tgz`
+  Creates tgz file in `/[project-home]/build/package.tgz`
+  NOTE: by default fhir-validator searching `package.tgz` in site root.
   You can override output file by specifying `:file` proprty in opts"
   [ig-ctx & {:as opts}]
   (let [file (or (:file opts)
-                 (io/file (:home ig-ctx) "build" (str (:id ig-ctx) ".tgz")))
+                 (io/file (:home ig-ctx) "build" "package.tgz"))
         resources (sd/project->structure-definitions ig-ctx)
         file-contents (generate-fhir-package-content ig-ctx resources)]
     (make-tgz-file file file-contents)))

--- a/src/igpop/site/core.clj
+++ b/src/igpop/site/core.clj
@@ -251,10 +251,12 @@
 
     (.mkdir (io/file build-dir "StructureDefinition"))
     (doseq [sd-id (keys (:path-by-sd-id ctx))]
+      (dump-page ctx home ["StructureDefinition" sd-id])
       (dump-page ctx home ["StructureDefinition" sd-id {:format "json"}]))
 
     (.mkdir (io/file build-dir "ValueSet"))
     (doseq [vs-id (keys (:path-by-vs-id ctx))]
+      (dump-page ctx home ["ValueSet" vs-id])
       (dump-page ctx home ["ValueSet" vs-id {:format "json"}]))
 
     (.mkdir (io/file build-dir "docs"))
@@ -285,4 +287,5 @@
 
   ;; (apply u/href {} ["StructureDefinition" (sd/make-profile-id (:id sd/ctx) :Adress :basic) {:format "json"}])
 
-  (handler {:uri "/" :request-method :get}))
+  ;; (handler {:uri "/" :request-method :get})
+  )


### PR DESCRIPTION
Rename FHIR package from  parametrized name - `[project-id].tgz`  to static name `package.tgz`

Renaming is forced by attempt to simplify resource validation - fhir-validator by default searching `package.tgz` in specified url. (when specified with `-ig` option)

Added structure-definition file doubles without `json` extensioin - to prevent 404 in static site.  This is temporary solution. In future we replace this hack with proper html page.